### PR TITLE
Removed unused imports - javafx import caused issue on build

### DIFF
--- a/src/main/java/org/launchcode/models/data/JobData.java
+++ b/src/main/java/org/launchcode/models/data/JobData.java
@@ -1,10 +1,8 @@
 package org.launchcode.models.data;
 
-import javafx.geometry.Pos;
 import org.launchcode.models.*;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 
 /**
  * Created by LaunchCode


### PR DESCRIPTION
javafx.geometry.Pos import causes issues upon first build of project.
This may cause unintentional issues for students working on this project.